### PR TITLE
Fix #11, static asset URLs on custom domains

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 name: Nspire
 safe: true
 exclude: [README.md, LICENSE.md, Gemfile, Gemfile.lock]
+baseurl: ''


### PR DESCRIPTION
Note: `nspire.github.io/nspire` will no longer work correctly.
