### PR TITLE
Safer secret token

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -9,4 +9,9 @@
 
 # Make sure your secret_key_base is kept private
 # if you're sharing your code publicly.
-Nspire::Application.config.secret_key_base = ENV['SECRET_TOKEN']
+
+Nspire::Application.config.secret_token = if Rails.env.development? or Rails.env.test?
+  ('x' * 30) # meets minimum requirement of 30 chars long
+else
+  ENV['SECRET_TOKEN']
+end


### PR DESCRIPTION
More secure `secret_token`.
Rails4 now requires `secret_key_base` or `secret_token` to be defined, otherwise an error is raised.
Changed `secret_key_base` to avoid deprecation warning.

Ref: 
http://daniel.fone.net.nz/blog/2013/05/20/a-better-way-to-manage-the-rails-secret-token/
